### PR TITLE
Install Dependencies And Configure PostgreSQL Database

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_BUILD__PG: "--with-opt-dir=/usr/local/opt/libpq"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+gem 'sinatra', '~> 4.0'
+gem 'rackup', '~> 2.1'
+gem 'puma', '~> 6.4', '>= 6.4.2'
+gem 'pg', '~> 1.5', '>= 1.5.7'
+gem 'activerecord', '~> 7.2', '>= 7.2.1'
+gem 'sinatra-activerecord', '~> 2.0', '>= 2.0.27'
+gem 'rake', '~> 13.2', '>= 13.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,77 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (7.2.1)
+      activesupport (= 7.2.1)
+    activerecord (7.2.1)
+      activemodel (= 7.2.1)
+      activesupport (= 7.2.1)
+      timeout (>= 0.4.0)
+    activesupport (7.2.1)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
+    concurrent-ruby (1.3.4)
+    connection_pool (2.4.1)
+    drb (2.2.1)
+    i18n (1.14.5)
+      concurrent-ruby (~> 1.0)
+    logger (1.6.0)
+    minitest (5.25.1)
+    mustermann (3.0.2)
+      ruby2_keywords (~> 0.0.1)
+    nio4r (2.7.3)
+    pg (1.5.7)
+    puma (6.4.2)
+      nio4r (~> 2.0)
+    rack (3.1.7)
+    rack-protection (4.0.0)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.0.0)
+      rack (>= 3.0.0)
+    rackup (2.1.0)
+      rack (>= 3)
+      webrick (~> 1.8)
+    rake (13.2.1)
+    ruby2_keywords (0.0.5)
+    securerandom (0.3.1)
+    sinatra (4.0.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.0.0)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    sinatra-activerecord (2.0.27)
+      activerecord (>= 4.1)
+      sinatra (>= 1.0)
+    tilt (2.4.0)
+    timeout (0.4.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    webrick (1.8.1)
+
+PLATFORMS
+  arm64-darwin-23
+  ruby
+
+DEPENDENCIES
+  activerecord (~> 7.2, >= 7.2.1)
+  pg (~> 1.5, >= 1.5.7)
+  puma (~> 6.4, >= 6.4.2)
+  rackup (~> 2.1)
+  rake (~> 13.2, >= 13.2.1)
+  sinatra (~> 4.0)
+  sinatra-activerecord (~> 2.0, >= 2.0.27)
+
+BUNDLED WITH
+   2.5.11

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,8 @@
+require 'sinatra/activerecord'
+require 'sinatra/activerecord/rake'
+
+namespace :db do
+  task :load_config do
+    require "./tito"
+  end
+end

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,6 @@
+require 'bundler'
+
+Bundler.require
+
+require './tito'
+run Tito

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,0 +1,18 @@
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  # For details on connection pooling, see rails configuration guide
+  # http://guides.rubyonrails.org/configuring.html#database-pooling
+  pool: 5
+
+development:
+  <<: *default
+  database: tito_development
+  username: postgres
+  password: <%= ENV["PG_PASSWORD"] %>
+
+production:
+  <<: *default
+  database: tito_production
+  # username: your_username
+  # password: your_password

--- a/tito.rb
+++ b/tito.rb
@@ -1,0 +1,5 @@
+require 'sinatra'
+
+get '/' do
+  'TITO LIVES!'
+end


### PR DESCRIPTION
Installed sinatra, bundler, puma, rackup, rake, postgres, sinatra-activerecord, and then created my tito_development database.

Installing PostgreSQL from source, and then installing the gem was the trickies bit. I needed to do this:

```BASH
export CONFIGURE_ARGS="with-pg-include=/Library/PostgreSQL/16/include/"
```
(source: https://stackoverflow.com/a/8831180)

to resolve this error:

>checking for libpq-fe.h... no
>Can't find the 'libpq-fe.h header

and then this:

```BASH
gem install pg -- --with-pg-config=/opt/homebrew/Cellar/libpq/16.4/bin/pg_config
```
(source: https://medium.com/@ssscripting/osx-cant-find-the-libpq-fe-h-header-e41b5a25041c)

to resolve this error:

>checking for PQconnectdb() in -lms/libpq... no
>Can't find the PostgreSQL client library (libpq)

I initially install install `libpq` with Homebrew, but then PostgreSQL from source, so I'm not sure if that was the source of some trouble in the libraries finding each other.