### PR TITLE
Generate git pull with deletions and additions for the same file

### DIFF
--- a/app/models/git_pull_parser.rb
+++ b/app/models/git_pull_parser.rb
@@ -1,13 +1,14 @@
 class GitPullParser
   attr_reader :changed_files
 
-  ChangedFile = Struct.new(:additions)
+  ChangedFile = Struct.new(:additions, :deletions)
   def parse(output)
     lines = lines_representing_changed_files(output)
 
     @changed_files = lines.map do |line|
       additions = parse_additions(line)
-      ChangedFile.new(additions: additions)
+      deletions = parse_deletions(line)
+      ChangedFile.new(additions: additions, deletions: deletions)
     end
 
     changed_files
@@ -25,5 +26,9 @@ class GitPullParser
 
   def parse_additions(line)
     line.split("|").last.split("+").last.strip.to_i
+  end
+
+  def parse_deletions(line)
+    line.split("|").last.split("-").first.strip.to_i
   end
 end

--- a/app/models/git_pull_parser.rb
+++ b/app/models/git_pull_parser.rb
@@ -6,8 +6,8 @@ class GitPullParser
     lines = lines_representing_changed_files(output)
 
     @changed_files = lines.map do |line|
-      additions = parse_additions(line)
-      deletions = parse_deletions(line)
+      additions = parse_addition_or_deletion(line, "+")
+      deletions = parse_addition_or_deletion(line, "-")
       ChangedFile.new(additions: additions, deletions: deletions)
     end
 
@@ -24,11 +24,7 @@ class GitPullParser
     output.split(/\n/).filter_map { |line| line if line.include?("|") }
   end
 
-  def parse_additions(line)
-    line.split("|").last.split("+").last.strip.to_i
-  end
-
-  def parse_deletions(line)
-    line.split("|").last.split("-").first.strip.to_i
+  def parse_addition_or_deletion(line, delimiter)
+    line.split("|").last.split(delimiter).first.strip.to_i
   end
 end

--- a/spec/models/git_pull_parser_spec.rb
+++ b/spec/models/git_pull_parser_spec.rb
@@ -20,4 +20,14 @@ RSpec.describe GitPullParser do
 
     expect(lines_of_code_added_to_first_changed_file).to eq(2)
   end
+
+  it "determines how many lines of code have been deleted from changed files" do
+    git_pull_parser = GitPullParser.new
+    output = File.read("spec/fixtures/git_pulls/git_pull_output-1725856246.txt")
+
+    git_pull_parser.parse(output)
+    lines_of_code_deleted_from_first_changed_file = git_pull_parser.changed_files.first.deletions
+
+    expect(lines_of_code_deleted_from_first_changed_file).to eq(5)
+  end
 end


### PR DESCRIPTION
Refactor GitPullParser to add and delete lines from the file, so that the git pull output will include both additions and eletions